### PR TITLE
Save latched messages outside of bag ranges

### DIFF
--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -219,6 +219,10 @@ public:
   // Return the total message size including the meta-information
   int64_t getMessageSize(SnapshotMessage const& msg) const;
 
+  const SnapshotMessage* findExtraLatchedMessage(const ros::Time& start,
+                                                 const ros::Time& stop) const;
+
+
 private:
   // Internal push whitch does not obtain lock
   void _push(SnapshotMessage const& msg);
@@ -297,9 +301,6 @@ private:
                   std::string const& topic,
                   rosbag_snapshot_msgs::TriggerSnapshot::Request& req,
                   rosbag_snapshot_msgs::TriggerSnapshot::Response& res);
-  const SnapshotMessage* findExtraLatchedMessage(const MessageQueue& queue,
-                                                 const ros::Time& start,
-                                                 const ros::Time& stop) const;
 };
 
 // Configuration for SnapshotterClient

--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -300,7 +300,6 @@ private:
   const SnapshotMessage* findExtraLatchedMessage(const MessageQueue& queue,
                                                  const ros::Time& start,
                                                  const ros::Time& stop) const;
-  static bool isLatched(const SnapshotMessage& msg);
 };
 
 // Configuration for SnapshotterClient

--- a/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
+++ b/rosbag_snapshot/include/rosbag_snapshot/snapshotter.h
@@ -292,9 +292,15 @@ private:
   void pollTopics(ros::TimerEvent const& e, rosbag_snapshot::SnapshotterOptions *options);
   // Write the parts of message_queue within the time constraints of req to the queue
   // If returns false, there was an error opening/writing the bag and an error message was written to res.message
-  bool writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, std::string const& topic,
+  bool writeTopic(rosbag::Bag& bag,
+                  MessageQueue& message_queue,
+                  std::string const& topic,
                   rosbag_snapshot_msgs::TriggerSnapshot::Request& req,
                   rosbag_snapshot_msgs::TriggerSnapshot::Response& res);
+  const SnapshotMessage* findExtraLatchedMessage(const MessageQueue& queue,
+                                                 const ros::Time& start,
+                                                 const ros::Time& stop) const;
+  static bool isLatched(const SnapshotMessage& msg);
 };
 
 // Configuration for SnapshotterClient

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -467,8 +467,7 @@ const SnapshotMessage* Snapshotter::findExtraLatchedMessage(const MessageQueue& 
   const MessageQueue::queue_t& q = queue.queue_;
   if (q.empty()) return nullptr;
 
-  const SnapshotMessage* last_before = nullptr;  
-  const SnapshotMessage* first_after = nullptr; 
+  const SnapshotMessage* last_before = nullptr;
 
   for (const auto& msg : q) {
     if (msg.time < start) {

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -398,14 +398,17 @@ void Snapshotter::subscribe(string const& topic, boost::shared_ptr<MessageQueue>
   queue->setSubscriber(sub);
 }
 
-bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, string const& topic,
+bool Snapshotter::writeTopic(rosbag::Bag& bag,
+                             MessageQueue& message_queue,
+                             string const& topic,
                              rosbag_snapshot_msgs::TriggerSnapshot::Request& req,
-                             rosbag_snapshot_msgs::TriggerSnapshot::Response& res)
-{
+                             rosbag_snapshot_msgs::TriggerSnapshot::Response& res) {
   // acquire lock for this queue
   boost::mutex::scoped_lock l(message_queue.lock);
 
   MessageQueue::range_t range = message_queue.rangeFromTimes(req.start_time, req.stop_time);
+
+  const SnapshotMessage* extra_latched_msg = findExtraLatchedMessage(message_queue, req.start_time, req.stop_time);
 
   // open bag if this the first valid topic and there is data
   if (!bag.isOpen() && range.second > range.first)
@@ -447,13 +450,37 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag, MessageQueue& message_queue, stri
       SnapshotMessage const& msg = *msg_it;
       bag.write(topic, msg.time, msg.msg, msg.connection_header);
     }
-  }
-  catch (rosbag::BagException const& err)
-  {
+    if (extra_latched_msg) {
+      bag.write(topic, req.start_time, extra_latched_msg->msg, extra_latched_msg->connection_header);
+    }
+  } catch (rosbag::BagException const& err) {
     res.success = false;
     res.message = string("failed to write bag: ") + err.what();
   }
   return true;
+}
+
+const SnapshotMessage* Snapshotter::findExtraLatchedMessage(const MessageQueue& queue,
+                                                            const ros::Time& start,
+                                                            const ros::Time& stop) const {
+ 
+  const MessageQueue::queue_t& q = queue.queue_;
+  if (q.empty()) return nullptr;
+
+  const SnapshotMessage* last_before = nullptr;  
+  const SnapshotMessage* first_after = nullptr; 
+
+  for (const auto& msg : q) {
+    if (msg.time < start) {
+      if (isLatched(msg)) last_before = &msg;
+    }
+  }
+  return last_before;
+}
+
+bool Snapshotter::isLatched(const SnapshotMessage& msg) {
+  return msg.connection_header && msg.connection_header->count("latching") &&
+         msg.connection_header->at("latching") == "1";
 }
 
 bool Snapshotter::triggerSnapshotCb(rosbag_snapshot_msgs::TriggerSnapshot::Request& req,

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -67,7 +67,8 @@ static bool is_topic_name_pattern(const std::string& s)
   return s.find_first_of(".*+?()[]{}\\") != std::string::npos;
 }
 
-static bool isLatched(const SnapshotMessage& msg) {
+static bool isLatched(const SnapshotMessage& msg)
+{
   return msg.connection_header && msg.connection_header->count("latching") &&
          msg.connection_header->at("latching") == "1";
 }
@@ -301,8 +302,7 @@ SnapshotMessage MessageQueue::_pop()
 }
 
 const SnapshotMessage* MessageQueue::findExtraLatchedMessage(const ros::Time& start, const ros::Time& stop) const
-{ 
-
+{
   const SnapshotMessage* last_before = nullptr;
   for (auto& msg : queue_)
   {
@@ -422,7 +422,8 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag,
                              MessageQueue& message_queue,
                              string const& topic,
                              rosbag_snapshot_msgs::TriggerSnapshot::Request& req,
-                             rosbag_snapshot_msgs::TriggerSnapshot::Response& res) {
+                             rosbag_snapshot_msgs::TriggerSnapshot::Response& res)
+                             {
   // acquire lock for this queue
   boost::mutex::scoped_lock l(message_queue.lock);
 
@@ -465,7 +466,8 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag,
   // write queue
   try
   {
-    if (extra_latched_msg) {
+    if (extra_latched_msg)
+    {
       bag.write(topic, req.start_time, extra_latched_msg->msg, extra_latched_msg->connection_header);
     }
     for (MessageQueue::range_t::first_type msg_it = range.first; msg_it != range.second; ++msg_it)
@@ -473,7 +475,9 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag,
       SnapshotMessage const& msg = *msg_it;
       bag.write(topic, msg.time, msg.msg, msg.connection_header);
     }
-  } catch (rosbag::BagException const& err) {
+  }
+  catch (rosbag::BagException const& err)
+  {
     res.success = false;
     res.message = string("failed to write bag: ") + err.what();
   }

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -300,6 +300,21 @@ SnapshotMessage MessageQueue::_pop()
   return tmp;
 }
 
+const SnapshotMessage* MessageQueue::findExtraLatchedMessage(const ros::Time& start, const ros::Time& stop) const
+{ 
+
+  const SnapshotMessage* last_before = nullptr;
+  for (auto& msg : queue_)
+  {
+    if (msg.time < start)
+    {
+      if (isLatched(msg))
+        last_before = &msg;
+    }
+  }
+  return last_before;
+}
+
 MessageQueue::range_t MessageQueue::rangeFromTimes(Time const& start, Time const& stop)
 {
   range_t::first_type begin = queue_.begin();
@@ -413,7 +428,7 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag,
 
   MessageQueue::range_t range = message_queue.rangeFromTimes(req.start_time, req.stop_time);
 
-  const SnapshotMessage* extra_latched_msg = findExtraLatchedMessage(message_queue, req.start_time, req.stop_time);
+  const SnapshotMessage* extra_latched_msg = message_queue.findExtraLatchedMessage(req.start_time, req.stop_time);
 
   // open bag if this the first valid topic and there is data
   if (!bag.isOpen() && range.second > range.first)
@@ -463,23 +478,6 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag,
     res.message = string("failed to write bag: ") + err.what();
   }
   return true;
-}
-
-const SnapshotMessage* Snapshotter::findExtraLatchedMessage(const MessageQueue& queue,
-                                                            const ros::Time& start,
-                                                            const ros::Time& stop) const {
- 
-  const MessageQueue::queue_t& q = queue.queue_;
-  if (q.empty()) return nullptr;
-
-  const SnapshotMessage* last_before = nullptr;
-
-  for (const auto& msg : q) {
-    if (msg.time < start) {
-      if (isLatched(msg)) last_before = &msg;
-    }
-  }
-  return last_before;
 }
 
 bool Snapshotter::triggerSnapshotCb(rosbag_snapshot_msgs::TriggerSnapshot::Request& req,

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -465,13 +465,13 @@ bool Snapshotter::writeTopic(rosbag::Bag& bag,
   // write queue
   try
   {
+    if (extra_latched_msg) {
+      bag.write(topic, req.start_time, extra_latched_msg->msg, extra_latched_msg->connection_header);
+    }
     for (MessageQueue::range_t::first_type msg_it = range.first; msg_it != range.second; ++msg_it)
     {
       SnapshotMessage const& msg = *msg_it;
       bag.write(topic, msg.time, msg.msg, msg.connection_header);
-    }
-    if (extra_latched_msg) {
-      bag.write(topic, req.start_time, extra_latched_msg->msg, extra_latched_msg->connection_header);
     }
   } catch (rosbag::BagException const& err) {
     res.success = false;

--- a/rosbag_snapshot/src/snapshotter.cpp
+++ b/rosbag_snapshot/src/snapshotter.cpp
@@ -67,6 +67,11 @@ static bool is_topic_name_pattern(const std::string& s)
   return s.find_first_of(".*+?()[]{}\\") != std::string::npos;
 }
 
+static bool isLatched(const SnapshotMessage& msg) {
+  return msg.connection_header && msg.connection_header->count("latching") &&
+         msg.connection_header->at("latching") == "1";
+}
+
 SnapshotterTopicOptions::SnapshotterTopicOptions(ros::Duration duration_limit, int32_t memory_limit,
                                                  int32_t count_limit)
   : duration_limit_(duration_limit), memory_limit_(memory_limit), count_limit_(count_limit)
@@ -475,11 +480,6 @@ const SnapshotMessage* Snapshotter::findExtraLatchedMessage(const MessageQueue& 
     }
   }
   return last_before;
-}
-
-bool Snapshotter::isLatched(const SnapshotMessage& msg) {
-  return msg.connection_header && msg.connection_header->count("latching") &&
-         msg.connection_header->at("latching") == "1";
 }
 
 bool Snapshotter::triggerSnapshotCb(rosbag_snapshot_msgs::TriggerSnapshot::Request& req,


### PR DESCRIPTION
Latched messages are currently stored in the snapshot recorder but they get dropped when we create the bug if they are older than the bag prescribed start time. 

In this PR the last messages received in the latched topics are saved in the bag and their timestamp is updated to match the bag start time